### PR TITLE
Add click-default-group 1.2.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - sk_test

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - sk_test

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,28 +10,37 @@ source:
   sha256: d9560e8e8dfa44b3562fbc9425042a0fd6d21956fcc2db0077f63f34253ab904
 
 build:
-  noarch: python
-  number: 1
-  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
+    - setuptools
+    - wheel
   run:
-    - python >=3.6
+    - python
     - click
 
 test:
   imports:
     - click_default_group
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/click-contrib/click-default-group
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
-  summary: 'Extends click.Group to invoke a command without explicit subcommand name.'
+  summary: Extends click.Group to invoke a command without explicit subcommand name.'
+  description: |
+    Extends click.Group to invoke a command without explicit subcommand name.
+    DefaultGroup is a sub class of click.Group. But it invokes a default subcommand 
+    instead of showing a help message when a subcommand is not passed.
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,9 @@ about:
     Extends click.Group to invoke a command without explicit subcommand name.
     DefaultGroup is a sub class of click.Group. But it invokes a default subcommand 
     instead of showing a help message when a subcommand is not passed.
-
+  dev_url: https://github.com/click-contrib/click-default-group
+  doc_url: https://github.com/click-contrib/click-default-group
+  
 extra:
   recipe-maintainers:
     - ericmjl


### PR DESCRIPTION
Releases: https://github.com/click-contrib/click-default-group/tags
License: https://github.com/click-contrib/click-default-group/blob/v1.2.2/LICENSE
Requirements: https://github.com/click-contrib/click-default-group/blob/v1.2.2/setup.py

Actions:
1. Reset build number to 0
2. Fix python in host and run
3. Add missing setuptools and wheel to host
4. Add pip check
5. Add description

Notes:
- conda-lock requires it